### PR TITLE
Fixed bug with find draft returning multiple elements

### DIFF
--- a/src/main/java/fi/metatavu/famifarm/drafts/DraftController.java
+++ b/src/main/java/fi/metatavu/famifarm/drafts/DraftController.java
@@ -1,5 +1,6 @@
 package fi.metatavu.famifarm.drafts;
 
+import java.util.List;
 import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -41,9 +42,22 @@ public class DraftController {
    * @return found draft or null if not found
    */
   public Draft findDraftByCreatorIdAndType(UUID creatorId, String type) {
-    return draftDAO.findByCreatorIdAndType(creatorId, type);
+    List<Draft> drafts = draftDAO.listByCreatorIdAndType(creatorId, type);
+    return drafts.isEmpty() ? null : drafts.get(drafts.size() - 1);
   }
-  
+
+  /**
+   * deletes drafts by creator id and type
+   * 
+   * @param creatorId creator id
+   * @param type type
+   */
+  public void deleteDraftsByCreatorIdAndType(UUID creatorId, String type) {
+    draftDAO.listByCreatorIdAndType(creatorId, type)
+      .stream()
+      .forEach(draftDAO::delete);
+  }
+
   /**
    * Deletes a draft
    * 

--- a/src/main/java/fi/metatavu/famifarm/persistence/dao/DraftDAO.java
+++ b/src/main/java/fi/metatavu/famifarm/persistence/dao/DraftDAO.java
@@ -1,5 +1,6 @@
 package fi.metatavu.famifarm.persistence.dao;
 
+import java.util.List;
 import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -40,13 +41,13 @@ public class DraftDAO extends AbstractDAO<Draft> {
   }
   
   /**
-   * Finds a draft by creator and type
+   * Lists drafts by creator and type
    * 
    * @param creatorId creatorId
    * @param type type
-   * @return found draft or null if not found
+   * @return list of found drafts
    */
-  public Draft findByCreatorIdAndType(UUID creatorId, String type) {
+  public List<Draft> listByCreatorIdAndType(UUID creatorId, String type) {
     EntityManager entityManager = getEntityManager();
 
     CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
@@ -58,7 +59,7 @@ public class DraftDAO extends AbstractDAO<Draft> {
       criteriaBuilder.equal(root.get(Draft_.creatorId), creatorId)
     ));
     
-    return getSingleResult(entityManager.createQuery(criteria));
+    return entityManager.createQuery(criteria).getResultList();
   }  
 
   /**

--- a/src/main/java/fi/metatavu/famifarm/rest/V1RESTService.java
+++ b/src/main/java/fi/metatavu/famifarm/rest/V1RESTService.java
@@ -1014,8 +1014,12 @@ public class V1RESTService extends AbstractApi implements V1Api {
   @Override
   @RolesAllowed({ Roles.ADMIN, Roles.MANAGER, Roles.WORKER })
   public Response createDraft(Draft body) {
+    UUID creatorId = getLoggerUserId();
+
+    //TODO: Add unique index to database to prevent duplicates created by ui errors
+    draftController.deleteDraftsByCreatorIdAndType(creatorId, body.getType());
     return createOk(
-        draftTranslator.translateDraft(draftController.createDraft(body.getType(), body.getData(), getLoggerUserId())));
+        draftTranslator.translateDraft(draftController.createDraft(body.getType(), body.getData(), creatorId)));
   }
 
   @Override


### PR DESCRIPTION
Fixes #118 , system now allows multiple drafts to be returned when listing drafts by user and draft type, in that case the latest one is returned. Before creating new draft, existing ones with the same userId and type are deleted. For future considerations there should be unique index added to draft with usedId + type fields. This should be done after a while so system has repaired itself.

